### PR TITLE
docs/main: embed Checkly data into static HTML

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,25 @@
+name: deno
+on: [push]
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed for auth with Deno Deploy
+      contents: read # Needed to clone the repository
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Build site
+        shell: bash
+        run: deno run --allow-read --allow-env --allow-net --allow-write docs/main.ts
+
+      - name: Upload to Deno Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: "croaky-webstack"
+          entrypoint: https://deno.land/std@0.131.0/http/file_server.ts
+          root: public

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -14,6 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build site
+        - uses: denoland/setup-deno@v1
+          with:
+            deno-version: v1.x
         shell: bash
         run: deno run --allow-read --allow-env --allow-net --allow-write docs/main.ts
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,6 +1,10 @@
 name: deno
 on: [push]
 
+env:
+  CHECKLY_ACCOUNT_ID: ${{ secrets.CHECKLY_ACCOUNT_ID }}
+  CHECKLY_API_KEY: ${{ secrets.CHECKLY_API_KEY }}
+
 jobs:
   deploy:
     name: deploy

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build site
-        - uses: denoland/setup-deno@v1
-          with:
-            deno-version: v1.x
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
         shell: bash
         run: deno run --allow-read --allow-env --allow-net --allow-write docs/main.ts
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -13,10 +13,12 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      - name: Build site
+     - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+
+      - name: Build site
         shell: bash
         run: deno run --allow-read --allow-env --allow-net --allow-write docs/main.ts
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
 
-     - name: Setup Deno
+      - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+public/*

--- a/docs/main.ts
+++ b/docs/main.ts
@@ -14,17 +14,20 @@ const resp = await fetch(
 );
 const data = await resp.json();
 
-const table = new AsciiTable("Web stacks last 7 days");
-table.setHeading("Name", "OK %", "Avg (ms)", "p95 (ms)");
+const table = new AsciiTable("API checks last 7 days");
+table.setHeading("Name", "OK (%)", "Avg (ms)", "p95 (ms)");
 table.setAlign(1, AsciiAlign.RIGHT);
 
 for (let i = 0; i < data.length; i++) {
   table.addRow(
     data[i]["name"],
-    `${data[i]["aggregate"]["successRatio"].toFixed(1)}%`,
+    data[i]["aggregate"]["successRatio"].toFixed(1),
     data[i]["aggregate"]["avg"],
     data[i]["aggregate"]["p95"]
   );
 }
 
-console.log(table.toString());
+const tmplHTML = await Deno.readTextFile("./docs/template.html");
+const genHTML = tmplHTML.replace("REPLACE_DASHBOARD_MAIN", table.toString());
+await Deno.mkdir("./public");
+await Deno.writeTextFile("./public/index.html", genHTML);

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <title>webstack</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="shortcut icon" type="image/png" href="favicon.ico">
   <style>
     @import url('https://rsms.me/inter/inter.css');
@@ -33,9 +36,6 @@
       border: none;
       width: 100%;
     }
-    .dash-main {
-      height: 960px;
-    }
     p,
     li {
       line-height: 1.5em;
@@ -45,8 +45,6 @@
     code {
       font-size: 1.15em;
       line-height: 1.25em;
-      margin: 0;
-      padding: 0;
     }
   </style>
   <script>
@@ -71,9 +69,15 @@
       <i>
         A project to prototype web stacks
         <a
-          href="https://github.com/croaky/webstack">github.com/croaky/webstack</a>
+          href="https://github.com/croaky/webstack">source code</a>
       </i>
     </p>
+
+    <pre>
+      <code>
+REPLACE_DASHBOARD_MAIN</code>
+    </pre>
+
     <p>
       <a href="https://heroku.com">Heroku</a> and "New Herokus":
     </p>
@@ -82,6 +86,7 @@
       <li><a href="https://railway.app">Railway</a></li>
       <li><a href="https://render.com">Render</a></li>
     </ul>
+
     <p>
       PaaS in your own AWS or GCP account:
     </p>
@@ -89,6 +94,7 @@
       <li><a href="https://encore.dev/">Encore</a> (TODO)</li>
       <li><a href="https://www.getporter.dev/">Porter</a> (TODO)</li>
     </ul>
+
     <p>
       Serverless functions:
     </p>
@@ -96,6 +102,7 @@
       <li><a href="https://deno.com/deploy">Deno Deploy</a></li>
       <li><a href="https://vercel.com">Vercel</a></li>
     </ul>
+
     <p>
       Each stack serves a healthcheck-style HTTP API endpoint that executes a
       <code>SELECT 1</code> to a SQL database
@@ -103,6 +110,7 @@
       Each stack uses a lightweight router, database connection pool,
       and SQL database driver (no ORM). Example:
     </p>
+
     <pre>
       <code>
 require "connection_pool"
@@ -119,12 +127,7 @@ get "/" do
   {status: "ok"}.to_json
 end</code>
     </pre>
-    <p>
-      API checks from N. California, Montreal, Ireland, Stockholm, and Sydney:
-    </p>
   </main>
-
-  <iframe class="dash-main" src="https://webstack.checklyhq.com/"></iframe>
 
   <!--
   <section id="ruby">
@@ -331,3 +334,4 @@ end</code>
     </p>
   </section>
 </body>
+</html>


### PR DESCRIPTION
Host with Deno Deploy via GitHub Action rather than GitHub Pages.