### PR TITLE
fly-go: try deploying with nixpacks

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -14,12 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: cd fly-go && flyctl deploy --remote-only
-
-  deploy-fly-ruby:
-    name: Deploy fly-ruby
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: cd fly-ruby && flyctl deploy --remote-only
+      - run: cd fly-go && flyctl deploy --remote-only --nixpacks

--- a/fly-go/fly.toml
+++ b/fly-go/fly.toml
@@ -6,10 +6,6 @@ kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []
 
-[build]
-  builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/go"]
-
 [env]
   PORT = "8080"
 


### PR DESCRIPTION
Pro: 88 MB image.
Con: failed w/o having local Docker installed:

```
% fly deploy --nixpacks --remote-only
==> Verifying app config
--> Verified app config
==> Building image
Remote builder fly-builder-name ready
Proxying local port /var/folders/random-id/docker.sock to remote [address]:port

╔═══════ Nixpacks v0.5.6 ══════╗
║ setup      │ go_1_18         ║
║──────────────────────────────║
║ install    │ go mod download ║
║──────────────────────────────║
║ build      │ go build -o out ║
║──────────────────────────────║
║ start      │ ./out           ║
╚══════════════════════════════╝

Error: Please install Docker to build the app https://docs.docker.com/engine/install/
Error failed to fetch an image or build from source: exit status 1
```