### PR TITLE
vercel-edge-planetscale: write to database

### DIFF
--- a/vercel-edge-planetscale/api/index.ts
+++ b/vercel-edge-planetscale/api/index.ts
@@ -10,7 +10,7 @@ const db = new Client({
 
 export default async function handler(_req: Request) {
   const conn = db.connection();
-  await conn.execute("SELECT 1");
+  await conn.execute("INSERT INTO checks (at) VALUES (now())");
 
   return new Response('{"status":"ok"}', {
     headers: {


### PR DESCRIPTION
For PlanetScale, write a row to the database.
Otherwise, it will sleep after 7 days due to inactivity,
which it defines as a write.

https://planetscale.com/docs/concepts/database-sleeping